### PR TITLE
Handle copy failures in legacy clipboard fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,10 +110,15 @@
           textArea.select();
           
           try {
-            document.execCommand('copy');
-            alert('✅ Registration copied to clipboard!\n\nNow open your email app and paste it into a new email.\n\nRecipient: robertjanice@bellsouth.net');
+            const copySuccessful = document.execCommand('copy');
+            if (copySuccessful) {
+              alert('✅ Registration copied to clipboard!\n\nNow open your email app and paste it into a new email.\n\nRecipient: robertjanice@bellsouth.net');
+            } else {
+              // Final fallback - show the text
+              alert('📧 EMAIL YOUR REGISTRATION\n\nCopy the text below and email it to: robertjanice@bellsouth.net\n\n' + fullText);
+            }
           } catch (err) {
-            // Final fallback - show the text
+            // If an error occurs, show the text
             alert('📧 EMAIL YOUR REGISTRATION\n\nCopy the text below and email it to: robertjanice@bellsouth.net\n\n' + fullText);
           }
           


### PR DESCRIPTION
## Summary
- Check `document.execCommand('copy')` return value when using the legacy clipboard fallback
- Show manual copy instructions if the command fails or throws an error

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bac8939f4083248b1177dae5fd9c8a