### PR TITLE
feat: email link opens mail client

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,86 +55,42 @@
     }
   </style>
   <script>
-    // Handle form submission
-    document.getElementById('registration-form').addEventListener('submit', function(e) {
-      e.preventDefault();
-      
-      
-      const formData = new FormData(this);
-      const data = Object.fromEntries(formData);
-      
-      // Create email body
-      let emailBody = 'BLACKTOP BASKETBALL CAMP REGISTRATION\n\n';
-      emailBody += `Paid Date: ${data.paid_date || 'Not provided'}\n`;
-      emailBody += `Amount Paid: ${data.amount_paid || 'Not provided'}\n`;
-      emailBody += `T-Shirt Size: ${data.shirt_size || 'Not provided'}\n\n`;
-      emailBody += 'PLAYER INFORMATION:\n';
-      emailBody += `Player's First Name: ${data.player_first_name || 'Not provided'}\n`;
-      emailBody += `Player's Last Name: ${data.player_last_name || 'Not provided'}\n`;
-      emailBody += `Age: ${data.age || 'Not provided'}\n`;
-      emailBody += `Date of Birth: ${data.dob || 'Not provided'}\n`;
-      emailBody += `Parent(s) Name: ${data.parent_name || 'Not provided'}\n`;
-      emailBody += `Address: ${data.address || 'Not provided'}\n`;
-      emailBody += `City & Zip: ${data.city_zip || 'Not provided'}\n`;
-      emailBody += `Cell Number: ${data.cell_number || 'Not provided'}\n`;
-      emailBody += `Alt Phone Number: ${data.alt_phone || 'Not provided'}\n`;
-      emailBody += `Guardian's Email: ${data.guardian_email || 'Not provided'}\n\n`;
-      emailBody += `Liability Release: ${data.liability_release ? 'Yes' : 'No'}\n`;
-      emailBody += `Photo Permission: ${data.photo_permission ? 'Yes' : 'No'}\n\n`;
-      emailBody += 'SIGNATURE:\n';
-      emailBody += `Parent/Guardian Name: ${data.guardian_signature_name || 'Not provided'}\n`;
-      emailBody += `Date: ${data.signature_date || 'Not provided'}\n`;
-      
-      // Show modal with email text for manual copy
-      showEmailModal(emailBody);
+    // Prepare mailto link with form data when the email link is clicked
+    document.addEventListener('DOMContentLoaded', function () {
+      const emailLink = document.getElementById('email-link');
+      const form = document.getElementById('registration-form');
+
+      emailLink.addEventListener('click', function () {
+        const formData = new FormData(form);
+        const data = Object.fromEntries(formData);
+
+        let emailBody = 'BLACKTOP BASKETBALL CAMP REGISTRATION\n\n';
+        emailBody += `Paid Date: ${data.paid_date || 'Not provided'}\n`;
+        emailBody += `Amount Paid: ${data.amount_paid || 'Not provided'}\n`;
+        emailBody += `T-Shirt Size: ${data.shirt_size || 'Not provided'}\n\n`;
+        emailBody += 'PLAYER INFORMATION:\n';
+        emailBody += `Player's First Name: ${data.player_first_name || 'Not provided'}\n`;
+        emailBody += `Player's Last Name: ${data.player_last_name || 'Not provided'}\n`;
+        emailBody += `Age: ${data.age || 'Not provided'}\n`;
+        emailBody += `Date of Birth: ${data.dob || 'Not provided'}\n`;
+        emailBody += `Parent(s) Name: ${data.parent_name || 'Not provided'}\n`;
+        emailBody += `Address: ${data.address || 'Not provided'}\n`;
+        emailBody += `City & Zip: ${data.city_zip || 'Not provided'}\n`;
+        emailBody += `Cell Number: ${data.cell_number || 'Not provided'}\n`;
+        emailBody += `Alt Phone Number: ${data.alt_phone || 'Not provided'}\n`;
+        emailBody += `Guardian's Email: ${data.guardian_email || 'Not provided'}\n\n`;
+        emailBody += `Liability Release: ${data.liability_release ? 'Yes' : 'No'}\n`;
+        emailBody += `Photo Permission: ${data.photo_permission ? 'Yes' : 'No'}\n\n`;
+        emailBody += 'SIGNATURE:\n';
+        emailBody += `Parent/Guardian Name: ${data.guardian_signature_name || 'Not provided'}\n`;
+        emailBody += `Date: ${data.signature_date || 'Not provided'}\n`;
+
+        const subject = encodeURIComponent('Blacktop Basketball Camp Registration');
+        const body = encodeURIComponent(emailBody);
+        this.href = `mailto:robertjanice@bellsouth.net?subject=${subject}&body=${body}`;
+      });
     });
-    
-    // Show email modal with copy functionality
-    function showEmailModal(emailBody) {
-      // Build full text including subject and recipient
-      const fullText = `Subject: Blacktop Basketball Camp Registration\n\nTo: robertjanice@bellsouth.net\n\n${emailBody}`;
 
-      // Create a simple modal
-      const modal = document.createElement('div');
-      modal.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.8);z-index:9999;display:flex;align-items:center;justify-content:center;padding:20px;';
-
-      const content = document.createElement('div');
-      content.style.cssText = 'background:white;border-radius:10px;padding:30px;max-width:500px;width:100%;max-height:80vh;overflow:auto;';
-
-      content.innerHTML = `
-        <h3 style="text-align:center;margin-bottom:20px;">📧 Email Your Registration</h3>
-        <p style="text-align:center;margin-bottom:20px;">Copy the text below and email it to: <strong>robertjanice@bellsouth.net</strong></p>
-        <textarea readonly style="width:100%;height:300px;padding:15px;border:2px solid #ddd;border-radius:5px;font-family:monospace;font-size:14px;box-sizing:border-box;">${fullText}</textarea>
-        <div style="text-align:center;margin:20px 0;">
-          <button onclick="copyText()" style="background:#3498db;color:white;border:none;padding:12px 24px;border-radius:5px;font-size:16px;cursor:pointer;margin-right:10px;">📋 Copy</button>
-          <button onclick="closeModal()" style="background:#95a5a6;color:white;border:none;padding:12px 24px;border-radius:5px;font-size:16px;cursor:pointer;">Close</button>
-        </div>
-        <p style="text-align:center;font-size:14px;color:#666;">After copying, open your email app and paste the text.</p>
-      `;
-
-      modal.appendChild(content);
-      document.body.appendChild(modal);
-
-      const textarea = content.querySelector('textarea');
-      textarea.addEventListener('click', () => textarea.select());
-
-      // Global functions
-      window.copyText = function() {
-        textarea.select();
-        try {
-          document.execCommand('copy');
-          alert('✅ Text copied! Open your email app and paste it to: robertjanice@bellsouth.net');
-        } catch (err) {
-          alert('Please manually select and copy the text above.');
-        }
-      };
-
-      window.closeModal = function() {
-        document.body.removeChild(modal);
-      };
-    }
-    
-    // Handle PDF download
     function downloadForm() {
       window.open('/blacktop-camp-registration-2023.pdf', '_blank');
     }
@@ -277,9 +233,9 @@
           </div>
           
           <div style="text-align:center; margin-top:30px;">
-            <button type="submit" style="background:#3498db; color:#fff; padding:15px 20px; border:none; border-radius:8px; font-size:16px; font-weight:bold; cursor:pointer; width:100%; margin-bottom:15px; display:block;">
+            <a id="email-link" href="mailto:robertjanice@bellsouth.net?subject=Blacktop%20Basketball%20Camp%20Registration" target="_blank" style="background:#3498db; color:#fff; padding:15px 20px; border:none; border-radius:8px; font-size:16px; font-weight:bold; cursor:pointer; width:100%; margin-bottom:15px; display:block; text-decoration:none; text-align:center;">
               📧 Email Registration
-            </button>
+            </a>
             <button type="button" onclick="downloadForm()" style="background:#27ae60; color:#fff; padding:15px 20px; border:none; border-radius:8px; font-size:16px; font-weight:bold; cursor:pointer; width:100%; display:block;">
               💾 Download PDF
             </button>


### PR DESCRIPTION
## Summary
- remove popup-based form submission
- add mailto email link that fills in form data

## Testing
- `npm run build`
- `node <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68bad2100f108324ad69a492a7fa06f9