### PR TITLE
Embed registration form PDF

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,23 +32,14 @@
     .download-btn:hover{background:#2980b9; transform:translateY(-1px)}
     .divider{ text-align:center; margin:12px 0 18px; color:#6c757d; font-size:.95rem; font-style:italic}
     .pdf-container{ margin:16px 0 30px; border:1px solid #e9ecef; border-radius:10px; overflow:hidden; box-shadow:0 2px 10px rgba(0,0,0,.05)}
-    .pdf-iframe{ width:100%; height:80vh; border:0; display:block }
     .pdf-viewer{ width:100%; height:80vh; border:0; display:block }
     .footer{ margin-top:20px; padding-top:20px; border-top:1px solid #e9ecef; font-size:.95rem; color:#6c757d; text-align:center}
     .download-icon{font-size:1.4rem}
-    .pdf-toolbar{ background:#f8f9fa; padding:10px; border-bottom:1px solid #e9ecef; display:flex; gap:10px; align-items:center; flex-wrap:wrap }
-    .pdf-toolbar button{ padding:8px 12px; border:1px solid #ddd; background:#fff; border-radius:4px; cursor:pointer; font-size:14px }
-    .pdf-toolbar button:hover{ background:#f8f9fa }
-    .pdf-toolbar .download-btn-small{ background:#3498db; color:#fff; border-color:#3498db }
-    .pdf-toolbar .download-btn-small:hover{ background:#2980b9 }
     @media (max-width:600px){
       .container{padding:25px}
       h1{font-size:1.8rem}
       .download-btn{padding:16px 24px; font-size:1.05rem}
-      .pdf-iframe{height:70vh}
       .pdf-viewer{height:70vh}
-      .pdf-toolbar{ padding:8px; gap:5px }
-      .pdf-toolbar button{ padding:6px 8px; font-size:12px }
       #registration-form{ padding:20px }
       #registration-form input, #registration-form select{ font-size:16px; padding:12px }
       #registration-form button{ padding:18px 20px; font-size:18px }
@@ -123,6 +114,7 @@
       </div>
 
       <div class="pdf-container" aria-label="Registration form">
+        <iframe class="pdf-viewer" src="/blacktop-camp-registration-2023.pdf"></iframe>
         <!-- HTML Form (works on all devices) -->
         <form id="registration-form" style="background:#fff; padding:30px; border-radius:10px; box-shadow:0 2px 10px rgba(0,0,0,.05);">
           <h3 style="text-align:center; margin-bottom:25px; color:#2c3e50;">BLACKTOP BASKETBALL CAMP REGISTRATION FORM</h3>


### PR DESCRIPTION
## Summary
- Embed the camp registration PDF directly in the page for inline viewing.
- Remove unused PDF iframe and toolbar styles.

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68baee8c18fc8324b21548e6ade7b37b