### PR TITLE
Ensure mailto body uses CRLF line breaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
         emailBody += 'Questions? Contact: robertjanice@bellsouth.net';
 
         const subject = encodeURIComponent('Blacktop Basketball Camp Registration');
-        const body = encodeURIComponent(emailBody);
+        const body = encodeURIComponent(emailBody.replace(/\n/g, "\r\n"));
         this.href = `mailto:robertjanice@bellsouth.net?subject=${subject}&body=${body}`;
       });
     });


### PR DESCRIPTION
## Summary
- fix email composition to replace `\n` with `\r\n` before encoding

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `node -e "const emailBody='line1\nline2'; console.log(encodeURIComponent(emailBody.replace(/\n/g, '\r\n')));"`

------
https://chatgpt.com/codex/tasks/task_e_68bafc89176883248b8bd9fa74adf91c