### PR TITLE
Use CRLF line breaks for email link

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,52 +50,56 @@
     document.addEventListener('DOMContentLoaded', function () {
       const emailLink = document.getElementById('email-link');
       const form = document.getElementById('registration-form');
+      const NL = '\r\n';
 
       emailLink.addEventListener('click', function () {
         const formData = new FormData(form);
         const data = Object.fromEntries(formData);
 
-        let emailBody = 'BLACKTOP BASKETBALL CAMP REGISTRATION\n\n';
-        emailBody += '==========================================\n\n';
-        
-        emailBody += 'PAYMENT INFORMATION\n';
-        emailBody += '------------------------------------------\n';
-        emailBody += `Paid Date: ${data.paid_date || 'Not provided'}\n`;
-        emailBody += `Amount Paid: ${data.amount_paid || 'Not provided'}\n`;
-        emailBody += `T-Shirt Size: ${data.shirt_size || 'Not provided'}\n\n`;
-        
-        emailBody += 'PLAYER INFORMATION\n';
-        emailBody += '------------------------------------------\n';
-        emailBody += `Player First Name: ${data.player_first_name || 'Not provided'}\n`;
-        emailBody += `Player Last Name: ${data.player_last_name || 'Not provided'}\n`;
-        emailBody += `Age: ${data.age || 'Not provided'}\n`;
-        emailBody += `Date of Birth: ${data.dob || 'Not provided'}\n\n`;
-        
-        emailBody += 'PARENT/GUARDIAN INFORMATION\n';
-        emailBody += '------------------------------------------\n';
-        emailBody += `Parent Name: ${data.parent_name || 'Not provided'}\n`;
-        emailBody += `Address: ${data.address || 'Not provided'}\n`;
-        emailBody += `City & Zip: ${data.city_zip || 'Not provided'}\n`;
-        emailBody += `Cell Number: ${data.cell_number || 'Not provided'}\n`;
-        emailBody += `Alt Phone: ${data.alt_phone || 'Not provided'}\n`;
-        emailBody += `Guardian Email: ${data.guardian_email || 'Not provided'}\n\n`;
-        
-        emailBody += 'PERMISSIONS\n';
-        emailBody += '------------------------------------------\n';
-        emailBody += `Liability Release: ${data.liability_release ? 'Yes' : 'No'}\n`;
-        emailBody += `Photo Permission: ${data.photo_permission ? 'Yes' : 'No'}\n\n`;
-        
-        emailBody += 'SIGNATURE\n';
-        emailBody += '------------------------------------------\n';
-        emailBody += `Parent/Guardian Name: ${data.guardian_signature_name || 'Not provided'}\n`;
-        emailBody += `Date: ${data.signature_date || 'Not provided'}\n\n`;
-        
-        emailBody += '==========================================\n';
-        emailBody += 'Thank you for registering!\n';
-        emailBody += 'Questions? Contact: robertjanice@bellsouth.net';
+        const lines = [
+          'BLACKTOP BASKETBALL CAMP REGISTRATION',
+          '',
+          '==========================================',
+          '',
+          'PAYMENT INFORMATION',
+          '------------------------------------------',
+          `Paid Date: ${data.paid_date || 'Not provided'}`,
+          `Amount Paid: ${data.amount_paid || 'Not provided'}`,
+          `T-Shirt Size: ${data.shirt_size || 'Not provided'}`,
+          '',
+          'PLAYER INFORMATION',
+          '------------------------------------------',
+          `Player First Name: ${data.player_first_name || 'Not provided'}`,
+          `Player Last Name: ${data.player_last_name || 'Not provided'}`,
+          `Age: ${data.age || 'Not provided'}`,
+          `Date of Birth: ${data.dob || 'Not provided'}`,
+          '',
+          'PARENT/GUARDIAN INFORMATION',
+          '------------------------------------------',
+          `Parent Name: ${data.parent_name || 'Not provided'}`,
+          `Address: ${data.address || 'Not provided'}`,
+          `City & Zip: ${data.city_zip || 'Not provided'}`,
+          `Cell Number: ${data.cell_number || 'Not provided'}`,
+          `Alt Phone: ${data.alt_phone || 'Not provided'}`,
+          `Guardian Email: ${data.guardian_email || 'Not provided'}`,
+          '',
+          'PERMISSIONS',
+          '------------------------------------------',
+          `Liability Release: ${data.liability_release ? 'Yes' : 'No'}`,
+          `Photo Permission: ${data.photo_permission ? 'Yes' : 'No'}`,
+          '',
+          'SIGNATURE',
+          '------------------------------------------',
+          `Parent/Guardian Name: ${data.guardian_signature_name || 'Not provided'}`,
+          `Date: ${data.signature_date || 'Not provided'}`,
+          '',
+          '==========================================',
+          'Thank you for registering!',
+          'Questions? Contact: robertjanice@bellsouth.net'
+        ];
 
         const subject = encodeURIComponent('Blacktop Basketball Camp Registration');
-        const body = encodeURIComponent(emailBody);
+        const body = encodeURIComponent(lines.join(NL));
         this.href = `mailto:robertjanice@bellsouth.net?subject=${subject}&body=${body}`;
       });
     });


### PR DESCRIPTION
## Summary
- Build mailto body from an array of lines and join with CRLFs
- Encode the joined body before setting the link href

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bafbf2b7188324955f924cfd06e06d